### PR TITLE
feat/about us

### DIFF
--- a/server/controllers/aboutUsController.js
+++ b/server/controllers/aboutUsController.js
@@ -4,5 +4,15 @@ const aboutUs = keystone.list('SobreNós');
 
 module.exports = {
 
+  getAboutUs(req, res) {
+    aboutUs.model.find((err, items) => {
+      if (err) {
+        console.log(err);
+        res.status(500).send('DB Error');
+      } 
+
+     res.status(200).json(items)
+    });
+  }
   
 }

--- a/server/controllers/aboutUsController.js
+++ b/server/controllers/aboutUsController.js
@@ -1,0 +1,8 @@
+const keystone = require('keystone');
+
+const aboutUs = keystone.list('SobreNós');
+
+module.exports = {
+
+  
+}

--- a/server/models/aboutUs.js
+++ b/server/models/aboutUs.js
@@ -2,6 +2,7 @@ const keystone = require('keystone');
 
 const { Types } = keystone.Field;
 
+
 // First we gonna create a aboutUs list
 const aboutUs = new keystone.List('SobreNós', {
   map: { name: 'key' },
@@ -11,18 +12,18 @@ const aboutUs = new keystone.List('SobreNós', {
 aboutUs.add({
   key: { type: Types.Text, default: 'Sobre Nós', initial: false },
   vision: {
-    text: { type: Types.Text, required: true, initial: true, label: 'Visão' },
+    text: { type: Types.Textarea, required: true, initial: true, label: 'Visão' },
     image_url: { type: Types.CloudinaryImage, required: true, initial: true, label: 'Imagem da visão'},
   },
   mission: {
-    text: { type: Types.Text, required: true, initial: true, label: 'Missão' },
+    text: { type: Types.Textarea, required: true, initial: true, label: 'Missão' },
     imageUrl: { type: Types.CloudinaryImage, required: true, initial: true, label: 'Imagem da missão'},
   },
   values: {
     valueArray: { type: Types.TextArray, required: true, initial: true, label: 'Valores' },
     imageUrl: { type: Types.CloudinaryImage, required: true, initial: true, label: 'Imagem dos valores'},
   },
-  companyHistory: { type: Types.Text, required: true, initial: true, label: 'História da empresa'}
+  companyHistory: { type: Types.Textarea, required: true, initial: true, label: 'História da empresa'}
 });
 
 aboutUs.register();

--- a/server/models/aboutUs.js
+++ b/server/models/aboutUs.js
@@ -1,0 +1,28 @@
+const keystone = require('keystone');
+
+const { Types } = keystone.Field;
+
+// First we gonna create a aboutUs list
+const aboutUs = new keystone.List('SobreNós', {
+  map: { name: 'key' },
+});
+
+// Then we gonna add the fields
+aboutUs.add({
+  key: { type: Types.Text, default: 'Sobre Nós', initial: false },
+  vision: {
+    text: { type: Types.Text, required: true, initial: true, label: 'Visão' },
+    image_url: { type: Types.CloudinaryImage, required: true, initial: true, label: 'Imagem da visão'},
+  },
+  mission: {
+    text: { type: Types.Text, required: true, initial: true, label: 'Missão' },
+    imageUrl: { type: Types.CloudinaryImage, required: true, initial: true, label: 'Imagem da missão'},
+  },
+  values: {
+    valueArray: { type: Types.TextArray, required: true, initial: true, label: 'Valores' },
+    imageUrl: { type: Types.CloudinaryImage, required: true, initial: true, label: 'Imagem dos valores'},
+  },
+  companyHistory: { type: Types.Text, required: true, initial: true, label: 'História da empresa'}
+});
+
+aboutUs.register();

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -2,6 +2,7 @@ const path = require('path');
 const cors = require('cors');
 
 const ourServicesController = require('../controllers/ourServicesController');
+const aboutUsController = require('../controllers/aboutUsController');
 
 module.exports = (app) => {
   app.use(cors());
@@ -11,5 +12,6 @@ module.exports = (app) => {
   });
 
   app.get('/api/our-services', ourServicesController.getOurServices);
+  app.get('/api/about-us', aboutUsController.getAboutUs);
 
 };


### PR DESCRIPTION
**What I did:**

- First the 'Example' model was deleted, because it was an unused file.
- After that, the route file (index) was edited to remove the route for the 'Example' model that no longer existed.
- So, after dealing with unused files, the 'aboutUs' model and its fields were created.
- Only the aboutUsController base was created.
- Created getAboutUs function in aboutUsController
- Finally, a get route was created to trigger the getAboutUs function.
- Changed text fields in the 'aboutUs' model to Textarea.

**How to test:**

- First:

Create a file named .env and, inside of it, place this:
````
PORT=[PORT]
MONGO_URI=[MONGO_URI]
COOKIE_SECRET=[COOKIE_SECRET]
CLOUDINARY_URL=[CLOUDINARY_URL]
Where:

[PORT] is which port you want the server to run on (usually 3001)
[MONGO_URI] Remote clouster or local DB
[COOKIE_SECRET] is a random string used for authentication on the admin.
[CLOUDINARY_URL] Copy API Environment variable in Cloudinary dashboard
````

- Second:
Run the server with **node index.js** command and access the **[URL]/api/our-services** route

resolves #5 